### PR TITLE
Fix service editing and quote pdf

### DIFF
--- a/interface/modules/cotacoes_backup.py
+++ b/interface/modules/cotacoes_backup.py
@@ -1251,8 +1251,8 @@ class CotacoesModule(BaseModule):
 			return
 		iid = selected[0]
 		vals = list(self.itens_tree.item(iid)['values'])
-		# Esperamos 13 colunas
-		if len(vals) != 13:
+		# Esperamos 14 colunas (inclui ICMS)
+		if len(vals) != 14:
 			return
 		modal = tk.Toplevel(self.frame)
 		modal.title("Editar Item da Proposta")
@@ -1271,6 +1271,7 @@ class CotacoesModule(BaseModule):
 			("Valor Total", 10),
 			("Descrição", 11),
 			("Operação", 12),
+			("ICMS", 13),
 		]
 		entries = {}
 		row = 0
@@ -1290,6 +1291,7 @@ class CotacoesModule(BaseModule):
 				desloc = clean_number(entries[5].get() or '0')
 				estadia = clean_number(entries[6].get() or '0')
 				meses = int(entries[7].get() or 0) if str(entries[7].get() or '').strip().isdigit() else 0
+				icms_val = clean_number(entries[13].get() or '0')
 				# Recalcular total (para locação usa meses; para compra soma custos)
 				if (entries[12].get() or '').lower().startswith('loca'):
 					total = (valor_unit or 0) * (meses or 0) * (qtd or 0)
@@ -1309,6 +1311,7 @@ class CotacoesModule(BaseModule):
 				vals[10] = format_currency(total)
 				vals[11] = entries[11].get().strip()
 				vals[12] = entries[12].get().strip() or 'Compra'
+				vals[13] = format_currency(icms_val)
 				self.itens_tree.item(iid, values=tuple(vals))
 				self.atualizar_total()
 				modal.destroy()

--- a/interface/modules/locacoes_full.py
+++ b/interface/modules/locacoes_full.py
@@ -917,7 +917,8 @@ class LocacoesModule(BaseModule):
 			return
 		iid = selected[0]
 		vals = list(self.itens_tree.item(iid)['values'])
-		if len(vals) != 9:
+		# Esperamos 10 colunas (inclui ICMS na última coluna)
+		if len(vals) != 10:
 			return
 		# Criar diálogo simples de edição
 		dialog = tk.Toplevel(self.frame)
@@ -932,6 +933,7 @@ class LocacoesModule(BaseModule):
 			("Fim (DD/MM/AAAA)", 5),
 			("Descrição", 7),
 			("Imagem", 8),
+			("ICMS", 9),
 		]
 		entries = {}
 		row = 0
@@ -966,6 +968,12 @@ class LocacoesModule(BaseModule):
 				vals[6] = format_currency(total)
 				vals[7] = descricao
 				vals[8] = imagem
+				# Preservar ICMS editado
+				try:
+					icms_val = clean_number(entries[9].get().strip() or '0')
+					vals[9] = format_currency(icms_val)
+				except Exception:
+					pass
 				self.itens_tree.item(iid, values=tuple(vals))
 				self._update_total()
 				dialog.destroy()

--- a/interface/modules/produtos.py
+++ b/interface/modules/produtos.py
@@ -848,6 +848,12 @@ class ProdutosModule(BaseModule):
                 self.nome_var.set(produto[1] or "")  # nome
                 self.tipo_var.set("Serviços")
                 self.descricao_var.set(produto[5] or "")  # descricao
+                # Garantir que o Valor Unitário também seja carregado para Serviços (Kit)
+                try:
+                    valor_unitario = produto[4] or 0
+                    self.valor_var.set(f"{valor_unitario:.2f}")
+                except Exception:
+                    pass
                 try:
                     if hasattr(self, 'esboco_servico_text'):
                         self.esboco_servico_text.delete("1.0", tk.END)


### PR DESCRIPTION
Ensures "Valor Unitário" loads for "Serviços" in "Cadastros" and preserves ICMS when editing items in service and rental quotations.

---
<a href="https://cursor.com/background-agent?bcId=bc-8ca55d4c-2441-4336-970a-715cd1554e85">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8ca55d4c-2441-4336-970a-715cd1554e85">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

