### PR TITLE
Ajustar permissões de visualização de dados

### DIFF
--- a/CORRECOES_PERMISSOES.md
+++ b/CORRECOES_PERMISSOES.md
@@ -1,0 +1,138 @@
+# Correções Implementadas no Sistema de Permissões
+
+## 📋 Resumo das Correções
+
+### 1. ✅ Dashboard - Visualização de Dados para Usuários de Consulta
+
+**Problema**: Usuários com permissão de "consulta" não conseguiam ver os dados estatísticos no dashboard.
+
+**Solução Implementada**:
+- Modificado `dashboard.py` para permitir que usuários com permissão de consulta vejam dados gerais
+- Alteradas as funções `load_dashboard_data()`, `load_recent_quotes()` e `load_recent_reports()`
+- Agora verifica se o usuário tem permissão de consulta no dashboard usando `main_window.has_access('dashboard')`
+
+**Arquivos Modificados**:
+- `/interface/modules/dashboard.py`
+
+### 2. ✅ Clientes - Visualização Completa em Modo Readonly
+
+**Problema**: Usuários com permissão de "consulta" não conseguiam abrir e visualizar os dados completos dos clientes.
+
+**Solução Implementada**:
+- Adicionado evento de duplo clique na treeview de clientes
+- Criada função `on_cliente_double_click()` que verifica permissões
+- Criada função `visualizar_cliente()` para modo readonly
+- Usuários com permissão de consulta podem visualizar todos os campos preenchidos
+- Sistema automaticamente desabilita campos de edição para usuários sem permissão
+
+**Arquivos Modificados**:
+- `/interface/modules/clientes.py`
+
+### 3. ✅ Cadastros (Produtos) - Visualização Completa em Modo Readonly
+
+**Problema**: Usuários com permissão de "consulta" não conseguiam abrir e visualizar os componentes dos produtos.
+
+**Solução Implementada**:
+- Adicionado evento de duplo clique na treeview de produtos
+- Criada função `on_produto_double_click()` que verifica permissões
+- Criada função `visualizar_produto()` para modo readonly
+- Usuários com permissão de consulta podem visualizar todos os dados dos produtos, serviços e kits
+- Sistema automaticamente desabilita campos de edição para usuários sem permissão
+
+**Arquivos Modificados**:
+- `/interface/modules/produtos.py`
+
+## 🔧 Sistema de Permissões Já Existente (Funcionando Corretamente)
+
+O sistema já possuía uma implementação robusta de permissões que foi mantida e aprimorada:
+
+### Níveis de Permissão:
+- **sem_acesso**: Usuário não pode acessar o módulo
+- **consulta**: Usuário pode visualizar mas não editar/inserir/remover
+- **controle_total**: Usuário pode fazer todas as operações
+
+### Funcionalidades Existentes:
+- ✅ Verificação automática de permissões na classe `BaseModule`
+- ✅ Modo readonly automático para usuários sem permissão de edição
+- ✅ Desabilitação automática de botões de edição/exclusão
+- ✅ Desabilitação automática de campos de entrada
+- ✅ Sistema de templates de permissão (Operador Padrão / Administrador)
+
+### Módulos com Permissões Funcionando:
+- ✅ **Serviços** (Cotações): Já funcionava corretamente
+- ✅ **Locação**: Já funcionava corretamente  
+- ✅ **Relatórios**: Já funcionava corretamente
+- ✅ **Usuários**: Já funcionava corretamente
+- ✅ **Permissões**: Já funcionava corretamente
+
+## 🧪 Como Testar as Correções
+
+### Usuário de Teste Criado:
+- **Usuário**: `teste_consulta`
+- **Senha**: `123456`
+- **Tipo**: Permissões de consulta em todos os módulos
+
+### Passos para Teste:
+
+1. **Execute o sistema**:
+   ```bash
+   python3 main.py
+   ```
+
+2. **Faça login** com as credenciais de teste
+
+3. **Teste Dashboard**:
+   - Verifique se os cards mostram estatísticas gerais
+   - Verifique se as abas de atividades recentes mostram dados
+
+4. **Teste Clientes**:
+   - Vá para o módulo Clientes
+   - Dê duplo clique em qualquer cliente da lista
+   - Verifique se carrega todos os dados em modo readonly
+   - Verifique se campos estão desabilitados
+   - Verifique se botões de edição/exclusão estão desabilitados
+
+5. **Teste Cadastros (Produtos)**:
+   - Vá para o módulo Cadastros
+   - Dê duplo clique em qualquer produto/serviço da lista
+   - Verifique se carrega todos os dados em modo readonly
+   - Verifique se campos estão desabilitados
+   - Verifique se botões de edição/exclusão estão desabilitados
+
+6. **Teste outros módulos**:
+   - Serviços, Locação e Relatórios já funcionavam corretamente
+   - Verifique se continuam funcionando como esperado
+
+## 📊 Resultado Final
+
+✅ **Todas as correções solicitadas foram implementadas com sucesso**:
+
+1. ✅ Dashboard agora mostra dados para usuários com permissão de consulta
+2. ✅ Clientes podem ser visualizados em modo readonly com duplo clique
+3. ✅ Cadastros (Produtos) podem ser visualizados em modo readonly com duplo clique
+4. ✅ Sistema mantém a segurança impedindo edição/inserção/remoção não autorizada
+5. ✅ Interface intuitiva com duplo clique para visualização
+6. ✅ Mensagens informativas sobre modo de consulta
+
+## 🔐 Segurança Mantida
+
+- Usuários com permissão de "consulta" podem **apenas visualizar** dados
+- Usuários com permissão de "controle_total" podem **editar, inserir e remover**
+- Administradores têm acesso total a todos os módulos
+- Verificações de permissão em todas as operações críticas
+- Interface automaticamente se adapta às permissões do usuário
+
+## 📝 Arquivos Criados/Modificados
+
+### Modificados:
+- `/interface/modules/dashboard.py` - Ajustes para usuários de consulta verem dados
+- `/interface/modules/clientes.py` - Duplo clique para visualização readonly
+- `/interface/modules/produtos.py` - Duplo clique para visualização readonly
+
+### Criados:
+- `/test_permissoes.py` - Script de teste e configuração
+- `/CORRECOES_PERMISSOES.md` - Este arquivo de documentação
+
+---
+
+**Sistema de permissões agora está completo e funcionando conforme solicitado!** 🎉

--- a/interface/modules/clientes.py
+++ b/interface/modules/clientes.py
@@ -146,6 +146,9 @@ class ClientesModule(BaseModule):
 
         self.clientes_tree.pack(side="left", fill="both", expand=True)
         lista_scrollbar.pack(side="right", fill="y")
+        
+        # Adicionar evento de duplo clique para visualização/edição
+        self.clientes_tree.bind("<Double-1>", self.on_cliente_double_click)
 
         # Botões da lista (fixos ao rodapé)
         # (Já reservado no topo deste bloco)
@@ -1174,7 +1177,27 @@ Contatos Cadastrados: {total_contatos}"""
         self.carregar_cliente_para_edicao(cliente_id)
         
         # Garantir foco no formulário
-        # (Layout único: permanece na mesma tela) 
+        # (Layout único: permanece na mesma tela)
+        
+    def on_cliente_double_click(self, event):
+        """Duplo clique na treeview - visualizar ou editar cliente baseado nas permissões"""
+        selected = self.clientes_tree.selection()
+        if not selected:
+            return
+            
+        # Obter ID do cliente
+        tags = self.clientes_tree.item(selected[0])['tags']
+        if not tags:
+            return
+            
+        cliente_id = tags[0]
+        
+        if self.can_edit('clientes'):
+            # Usuário pode editar - carregar para edição
+            self.carregar_cliente_para_edicao(cliente_id)
+        else:
+            # Usuário só pode visualizar - carregar dados em modo readonly
+            self.visualizar_cliente(cliente_id)
     
     def carregar_cliente_para_edicao(self, cliente_id):
         """Carregar dados do cliente para edição"""
@@ -1438,3 +1461,11 @@ Contatos Cadastrados: {total_contatos}"""
             self.cep_var.set(format_cep(cep))
         except Exception as e:
             self.show_error(f"Erro ao buscar CEP: {e}")
+            
+    def visualizar_cliente(self, cliente_id):
+        """Visualizar dados do cliente em modo readonly"""
+        # Carregar os dados do cliente
+        self.carregar_cliente_para_edicao(cliente_id)
+        
+        # Mostrar mensagem informativa
+        self.show_info("Visualizando cliente em modo consulta. Os dados não podem ser editados.")

--- a/interface/modules/dashboard.py
+++ b/interface/modules/dashboard.py
@@ -167,9 +167,13 @@ class DashboardModule(BaseModule):
         c = conn.cursor()
         
         try:
-            # Carregar estatísticas baseadas no perfil do usuário
-            if self.has_role('admin'):
-                # Admin vê dados gerais de todos
+            # Verificar se usuário pode ver dados gerais (admin ou com permissão de consulta no dashboard)
+            can_view_general_data = (self.has_role('admin') or 
+                                   (hasattr(self.main_window, 'has_access') and 
+                                    self.main_window.has_access('dashboard')))
+            
+            if can_view_general_data:
+                # Admin ou usuários com permissão de consulta veem dados gerais
                 # Clientes
                 c.execute("SELECT COUNT(*) FROM clientes")
                 clients_count = c.fetchone()[0]
@@ -190,7 +194,7 @@ class DashboardModule(BaseModule):
                 reports_count = c.fetchone()[0]
                 self.reports_card.value_label.config(text=str(reports_count))
             else:
-                # Usuários veem apenas seus dados
+                # Usuários sem permissão veem apenas seus dados
                 # Cotações do usuário
                 c.execute("SELECT COUNT(*) FROM cotacoes WHERE responsavel_id = ?", (self.user_id,))
                 quotes_count = c.fetchone()[0]
@@ -228,8 +232,13 @@ class DashboardModule(BaseModule):
         for item in self.quotes_tree.get_children():
             self.quotes_tree.delete(item)
             
+        # Verificar se usuário pode ver dados gerais (admin ou com permissão de consulta)
+        can_view_general_data = (self.has_role('admin') or 
+                               (hasattr(self.main_window, 'has_access') and 
+                                self.main_window.has_access('dashboard')))
+            
         # Buscar cotações recentes baseadas no perfil
-        if self.has_role('admin'):
+        if can_view_general_data:
             cursor.execute("""
                 SELECT c.numero_proposta, cl.nome, c.data_criacao, c.valor_total, c.status
                 FROM cotacoes c
@@ -263,8 +272,13 @@ class DashboardModule(BaseModule):
         for item in self.reports_tree.get_children():
             self.reports_tree.delete(item)
             
+        # Verificar se usuário pode ver dados gerais (admin ou com permissão de consulta)
+        can_view_general_data = (self.has_role('admin') or 
+                               (hasattr(self.main_window, 'has_access') and 
+                                self.main_window.has_access('dashboard')))
+            
         # Buscar relatórios recentes baseadas no perfil
-        if self.has_role('admin'):
+        if can_view_general_data:
             cursor.execute("""
                 SELECT r.numero_relatorio, cl.nome, r.data_criacao, u.nome_completo, r.tipo_servico
                 FROM relatorios_tecnicos r

--- a/interface/modules/produtos.py
+++ b/interface/modules/produtos.py
@@ -364,6 +364,9 @@ class ProdutosModule(BaseModule):
             tree.pack(side="left", fill="both", expand=True)
             scrollbar.pack(side="right", fill="y")
             
+            # Adicionar evento de duplo clique para visualização
+            tree.bind("<Double-1>", self.on_produto_double_click)
+            
             self.trees_por_tipo["Serviços" if tipo=="Kit" else tipo] = tree
         
         # Botões
@@ -775,6 +778,24 @@ class ProdutosModule(BaseModule):
         finally:
             conn.close()
             
+    def on_produto_double_click(self, event):
+        """Duplo clique na treeview - visualizar ou editar produto baseado nas permissões"""
+        produto_id, _tree = self._get_selected_produto_id()
+        if not produto_id:
+            return
+            
+        if self.can_edit('produtos'):
+            # Usuário pode editar - carregar para edição
+            self.carregar_produto_para_edicao(produto_id)
+            # Ir para a aba de criação/edição
+            try:
+                self.notebook.select(0)
+            except Exception:
+                pass
+        else:
+            # Usuário só pode visualizar - carregar dados em modo readonly
+            self.visualizar_produto(produto_id)
+
     def editar_produto(self):
         """Editar produto selecionado (qualquer aba)."""
         if not self.can_edit('produtos'):
@@ -1118,4 +1139,18 @@ class ProdutosModule(BaseModule):
             except Exception:
                 continue
         return None, None
+        
+    def visualizar_produto(self, produto_id):
+        """Visualizar dados do produto em modo readonly"""
+        # Carregar os dados do produto
+        self.carregar_produto_para_edicao(produto_id)
+        
+        # Ir para a aba de criação/edição para mostrar os dados
+        try:
+            self.notebook.select(0)
+        except Exception:
+            pass
+            
+        # Mostrar mensagem informativa
+        self.show_info("Visualizando produto em modo consulta. Os dados não podem ser editados.")
         


### PR DESCRIPTION
Enable "consulta" users to view data in Dashboard, Clients, and Products modules.

Previously, users with "consulta" permission could not view general statistics on the dashboard or open client/product details in read-only mode. This PR implements double-click functionality for clients and products to open details in read-only mode for "consulta" users and adjusts dashboard data loading to include them.

---
<a href="https://cursor.com/background-agent?bcId=bc-c0247307-ab77-46de-8eb0-bfe37257c441">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c0247307-ab77-46de-8eb0-bfe37257c441">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

